### PR TITLE
geometry functions now works with top window

### DIFF
--- a/orcsome/xlib.py
+++ b/orcsome/xlib.py
@@ -235,6 +235,8 @@ ffi.cdef("""
     Status XGetGeometry(Display *display, Drawable d, Window *root_return,
         int *x_return, int *y_return, unsigned int *width_return,
         unsigned int *height_return, unsigned int *border_width_return, unsigned int *depth_return);
+    Status XQueryTree(Display *display, Window w, Window *root_return, Window *parent_return,
+        Window **children_return, unsigned int *nchildren_return);
 
     Status XScreenSaverQueryInfo(Display *dpy, Drawable drawable, XScreenSaverInfo *saver_info);
 


### PR DESCRIPTION
Now it resolves top-level window (with wm decorations) to obtain/change geometry. Not sure if cycle condition is reliable, but can't find any bugs here
